### PR TITLE
Fix grid left overrun

### DIFF
--- a/build/media_source/system/js/fields/pagebuilder/components/elements/grid.vue
+++ b/build/media_source/system/js/fields/pagebuilder/components/elements/grid.vue
@@ -244,7 +244,9 @@
         // Be sure that there is space for offset
         if (column.x === 0) {
           this.moveToRight(column.x, column.y, offset);
-        }
+        } else if(column.x < offset) { // if offset run over left border push it back
+            column.x = offset;
+		}
 
         const offsetObj = {
           i: `offset-${column.element.key}`,

--- a/build/media_source/system/js/fields/pagebuilder/components/elements/grid.vue
+++ b/build/media_source/system/js/fields/pagebuilder/components/elements/grid.vue
@@ -245,7 +245,8 @@
         if (column.x === 0) {
           this.moveToRight(column.x, column.y, offset);
         } else if(column.x < offset) { // if offset run over left border push it back
-            column.x = offset;
+          this.moveToRight(offset, column.y, offset);
+          //column.x = offset;
 		}
 
         const offsetObj = {
@@ -365,16 +366,19 @@
         this.resetOffsets();
         this.resetHeight();
         this.positioning();
-        this.initOffsets();
-        this.setHeight();
-        this.setResizeListeners();
+        this.$nextTick(() => {
+          this.initOffsets();
+          this.setHeight();
+          this.setResizeListeners();
 
-        if (this.moved) {
-          const colElements = [];
-          this.columns.forEach(col => colElements.push(col.element));
-          this.updateChildrenOrder({parent: this.grid, children: colElements});
-          this.moved = false;
-        }
+          if (this.moved) {
+            const colElements = [];
+            this.columns.forEach(col => colElements.push(col.element));
+            this.updateChildrenOrder({parent: this.grid, children: colElements});
+            this.moved = false;
+          }
+        })
+
       },
       positioning() {
         // Bring columns in correct order to fill gaps one after another


### PR DESCRIPTION

### Summary of Changes
Simply move a grid element inside back, respecting its offset.


### Testing Instructions
Move a grid with offset outside the left border, it should be pushed back.


### Expected result
A grid with offset can not be moved outside.


### Actual result
Currently a grid with offset can be moved outside the area.


### Documentation Changes Required

